### PR TITLE
WIP: allow components to render when a new Experience entry is first created [ALT-106]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,58 @@
         "lint-staged": "^14.0.1"
       }
     },
+    "../experience-builder/packages/experience-builder-sdk": {
+      "name": "@contentful/experience-builder",
+      "version": "2.8.5",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/experience-builder-types": "^1.2.2",
+        "@contentful/rich-text-types": "^16.2.1",
+        "@contentful/visual-sdk": "^1.0.0-alpha.26",
+        "classnames": "^2.3.2",
+        "contentful": "^10.6.10",
+        "csstype": "^3.1.2",
+        "lodash.get": "^4.4.2",
+        "lodash.omit": "^4.5.0",
+        "lodash.random": "^3.2.0",
+        "lodash.throttle": "^4.1.1",
+        "lodash.times": "^4.3.2",
+        "md5": "^2.3.0",
+        "vite-plugin-css-injected-by-js": "^3.1.1"
+      },
+      "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@testing-library/jest-dom": "^6.1.4",
+        "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.4.3",
+        "@types/jest": "^29.5.6",
+        "@types/lodash.get": "^4.4.7",
+        "@types/lodash.omit": "^4.5.7",
+        "@types/lodash.throttle": "^4.1.7",
+        "@types/node": "^18.14.0",
+        "@types/react": "^18.0.28",
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "@vitejs/plugin-react-swc": "^3.0.0",
+        "husky": "^8.0.3",
+        "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.5.0",
+        "jsdom": "^21.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "rollup-plugin-peer-deps-external": "^2.2.4",
+        "semantic-release": "19.0.5",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.2.2",
+        "vite": "^4.3.9",
+        "vite-plugin-dts": "^3.6.1",
+        "vite-plugin-svgr": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "dev": true,
@@ -2775,28 +2827,8 @@
       }
     },
     "node_modules/@contentful/experience-builder": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@contentful/experience-builder/-/experience-builder-2.8.4.tgz",
-      "integrity": "sha512-vAJoNtu0WTndFFF3u6LwdroGGXM+q4RxDClFdJrQSJV36QRAnMgJoUIvK55giGmq4bI0a4IzNBBujHFmEXzuDQ==",
-      "dependencies": {
-        "@contentful/experience-builder-types": "^1.2.1",
-        "@contentful/rich-text-types": "^16.2.1",
-        "@contentful/visual-sdk": "^1.0.0-alpha.26",
-        "classnames": "^2.3.2",
-        "contentful": "^10.3.0",
-        "csstype": "^3.1.2",
-        "lodash.get": "^4.4.2",
-        "lodash.omit": "^4.5.0",
-        "lodash.random": "^3.2.0",
-        "lodash.throttle": "^4.1.1",
-        "lodash.times": "^4.3.2",
-        "md5": "^2.3.0",
-        "vite-plugin-css-injected-by-js": "^3.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
+      "resolved": "../experience-builder/packages/experience-builder-sdk",
+      "link": true
     },
     "node_modules/@contentful/experience-builder-components": {
       "resolved": "packages/components",
@@ -2805,15 +2837,6 @@
     "node_modules/@contentful/experience-builder-storybook-addon": {
       "resolved": "packages/storybook-addon",
       "link": true
-    },
-    "node_modules/@contentful/experience-builder-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/experience-builder-types/-/experience-builder-types-1.2.1.tgz",
-      "integrity": "sha512-iMiytbSfmBGYfnBL0bDgzLMFlISwAmFJaUnkQuo/Rw/PrvRWOFPk4Kz6pmbKFq+Q0AxEtXdDkr4R04kFYkPnJA==",
-      "dependencies": {
-        "@contentful/visual-sdk": "^1.0.0-alpha.26",
-        "contentful": "^10.3.0"
-      }
     },
     "node_modules/@contentful/f36-accordion": {
       "version": "4.52.3",
@@ -3600,10 +3623,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@contentful/visual-sdk": {
-      "version": "1.0.0-alpha.26",
-      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4420,7 +4439,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -9731,8 +9750,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "license": "MIT",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -10217,7 +10237,7 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/builtin-modules": {
@@ -10499,13 +10519,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "dev": true,
@@ -10572,10 +10585,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -11080,6 +11089,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "dev": true,
@@ -11112,11 +11130,12 @@
       }
     },
     "node_modules/contentful": {
-      "version": "10.6.4",
-      "license": "MIT",
+      "version": "10.6.10",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.6.10.tgz",
+      "integrity": "sha512-9i3Op+6QatXzPGc3dEUHpl2VjKOQ7QX+leelUTbXFWXTI5Mh54+OfiRYdqDxZUPtySHWHU2z0rNQp6a4DzsTKQ==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^1.4.0",
+        "axios": "^1.6.0",
         "contentful-resolve-response": "^1.8.1",
         "contentful-sdk-core": "^8.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -11184,8 +11203,9 @@
       "license": "MIT"
     },
     "node_modules/contentful/node_modules/type-fest": {
-      "version": "4.6.0",
-      "license": "(MIT OR CC0-1.0)",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
       "engines": {
         "node": ">=16"
       },
@@ -11529,13 +11549,6 @@
       "version": "17.0.45",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -13964,6 +13977,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15415,10 +15429,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "license": "MIT"
     },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
@@ -17703,6 +17713,7 @@
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isfunction": {
@@ -17743,19 +17754,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.random": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.random/-/lodash.random-3.2.0.tgz",
-      "integrity": "sha512-A6Vn7teN0+qSnhOsE8yx2bGowCS1G7D9e5abq8VhwOP98YHS/KrGMf43yYxA05lvcvloT+W9Z2ffkSajFTcPUA=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -17771,15 +17773,6 @@
       "version": "4.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "license": "MIT"
-    },
-    "node_modules/lodash.times": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.times/-/lodash.times-4.3.2.tgz",
-      "integrity": "sha512-FfaJzl0SA35CRPDh5SWe2BTght6y5KSK7yJv166qIp/8q7qOwBDCvuDZE2RUSMRpBkLF6rZKbLEUoTmaP3qg6A=="
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -18005,15 +17998,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -20371,6 +20355,7 @@
     },
     "node_modules/postcss": {
       "version": "8.4.31",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -22612,6 +22597,7 @@
     },
     "node_modules/rollup": {
       "version": "3.29.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -23355,6 +23341,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -23362,7 +23349,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -23371,7 +23358,7 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -24098,7 +24085,7 @@
     },
     "node_modules/terser": {
       "version": "5.22.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -24115,7 +24102,7 @@
     },
     "node_modules/terser/node_modules/acorn": {
       "version": "8.10.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -24126,7 +24113,7 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-app": {
@@ -25222,6 +25209,7 @@
     },
     "node_modules/vite": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -25273,11 +25261,19 @@
         }
       }
     },
-    "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "3.3.0",
-      "license": "MIT",
+    "node_modules/vite-plugin-rewrite-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz",
+      "integrity": "sha512-W0DAchC8ynuQH0lYLIu5/5+JGfYlUTRD8GGNtHFXRJX4FzzB9MajtqHBp26zq/ly9sDt5BqrfdT08rv3RbB0LQ==",
+      "dev": true,
+      "dependencies": {
+        "connect-history-api-fallback": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
-        "vite": ">2.0.0-0"
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/vite-plugin-svgr": {
@@ -25298,6 +25294,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25309,6 +25306,7 @@
     },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.18.20",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -26068,10 +26066,10 @@
     "packages/test-app": {
       "version": "0.0.0",
       "dependencies": {
-        "@contentful/experience-builder": "^2.8.4",
+        "@contentful/experience-builder": "file:../../../experience-builder/packages/experience-builder-sdk",
         "@contentful/experience-builder-components": "*",
         "@contentful/experience-builder-storybook-addon": "*",
-        "contentful": "^10.5.1",
+        "contentful": "^10.6.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0"
@@ -26097,7 +26095,8 @@
         "rimraf": "^5.0.5",
         "storybook": "^7.5.1",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.4.5",
+        "vite-plugin-rewrite-all": "^1.0.1"
       }
     },
     "packages/test-app/node_modules/@storybook/testing-library": {
@@ -26171,22 +26170,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "packages/test-app/node_modules/contentful": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.5.1.tgz",
-      "integrity": "sha512-1u1bMTruD1CJiCk5pBIn+ixMTSSl51AD4f2yXZ9G0uh3x+K3rasCojclM/GO9gF4WcNzdYe1ph+ILeOaEyTW3A==",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^1.4.0",
-        "contentful-resolve-response": "^1.8.1",
-        "contentful-sdk-core": "^8.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "type-fest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/test-app/node_modules/glob": {
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
@@ -26240,17 +26223,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/test-app/node_modules/type-fest": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
-      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -18,7 +18,7 @@
     "@contentful/experience-builder": "^2.8.4",
     "@contentful/experience-builder-components": "*",
     "@contentful/experience-builder-storybook-addon": "*",
-    "contentful": "^10.5.1",
+    "contentful": "^10.6.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0"
@@ -44,6 +44,7 @@
     "rimraf": "^5.0.5",
     "storybook": "^7.5.1",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-plugin-rewrite-all": "^1.0.1"
   }
 }

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -1,4 +1,8 @@
-import { useFetchExperience, defineComponents, ExperienceRoot } from '@contentful/experience-builder';
+import {
+  useFetchExperience,
+  defineComponents,
+  ExperienceRoot,
+} from '@contentful/experience-builder';
 import React, { useEffect, useMemo } from 'react';
 import { createClient } from 'contentful';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -12,7 +16,7 @@ const Page: React.FC = () => {
   const [qs] = useSearchParams();
 
   // Configure Content Preview URL in your space settings to include "/{entry.fields.slug}"
-  const { slug = 'SLUG_MISSING_FROM_URL' } = useParams<{ slug: string }>();
+  const { slug = '/' } = useParams<{ slug: string }>();
 
   // Run preview mode when loaded in an iframe or if the url contains isPreview=true
   const isPreview = window.self !== window.top || qs.get('isPreview') === 'true';
@@ -40,10 +44,6 @@ const Page: React.FC = () => {
   }, [fetchBySlug, localeCode, slug]);
 
   useExperienceBuilderComponents(defineComponents);
-
-  if (!experience) {
-    return null;
-  }
 
   return <ExperienceRoot experience={experience} locale={localeCode} />;
 };

--- a/packages/test-app/vite.config.ts
+++ b/packages/test-app/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import pluginRewriteAll from 'vite-plugin-rewrite-all';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), pluginRewriteAll()],
 });


### PR DESCRIPTION
This change will allow the `<ExperienceRoot>` component to render when creating a new page and before it has been saved in the database.  

The `vite-plugin-rewrite-all` was added to allow the router to work for the slug `entry.fields.slug_NOT_FOUND` containing dots (which is the URL in the iFrame target when the page is first created)

Background context
* With the changes in #40, when a new Experience type is first created the components fail to load in the left sidebar and the iFrame app renders a blank canvas because the `fetchBySlug()` method fails to find the new page when it's first created:

  > Failed to fetch experience with error: No experience entry with slug: `entry.fields.slug_NOT_FOUND` exists

Depends on SDK change
* A related change was made in the SDK `<ExperienceRoot>` component:
  contentful/experience-builder#164

TODO:
- [ ] Update SDK version after the SDK change above is approved/merged