### PR TITLE
fix(test-app): update sdk to v2.8.0 [ALT-104]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -313,6 +314,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.23.2",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -320,6 +322,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.23.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -348,6 +351,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -355,6 +359,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.23.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.23.0",
@@ -390,6 +395,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.22.15",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
@@ -404,6 +410,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -480,6 +487,7 @@
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -487,6 +495,7 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.23.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -498,6 +507,7 @@
     },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.22.5",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -529,6 +539,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.23.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -597,6 +608,7 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.22.5",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -618,6 +630,7 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.22.6",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
@@ -642,6 +655,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.22.15",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -662,6 +676,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.23.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.22.15",
@@ -2259,6 +2274,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
@@ -2271,6 +2287,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.23.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
@@ -2307,8 +2324,7 @@
     },
     "node_modules/@clack/core": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.3.tgz",
-      "integrity": "sha512-5ZGyb75BUBjlll6eOa1m/IZBxwk91dooBWhPSL67sWcLS0zt9SnswRL0l26TVdBhb0wnWORRxUn//uH6n4z7+A==",
+      "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
@@ -2316,20 +2332,19 @@
     },
     "node_modules/@clack/prompts": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.7.0.tgz",
-      "integrity": "sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==",
       "bundleDependencies": [
         "is-unicode-supported"
       ],
+      "license": "MIT",
       "dependencies": {
         "@clack/core": "^0.3.3",
-        "is-unicode-supported": "*",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2757,42 +2772,42 @@
       }
     },
     "node_modules/@contentful/experience-builder": {
-      "version": "2.0.2",
+      "version": "2.11.1",
       "license": "MIT",
       "dependencies": {
+        "@contentful/experience-builder-types": "^1.3.1",
         "@contentful/rich-text-types": "^16.2.1",
-        "@contentful/visual-sdk": "^1.0.0-alpha.9",
+        "@contentful/visual-sdk": "^1.0.0-alpha.26",
         "classnames": "^2.3.2",
-        "contentful": "^10.3.0",
+        "contentful": "^10.6.10",
         "csstype": "^3.1.2",
         "lodash.get": "^4.4.2",
         "lodash.omit": "^4.5.0",
+        "lodash.random": "^3.2.0",
         "lodash.throttle": "^4.1.1",
+        "lodash.times": "^4.3.2",
         "md5": "^2.3.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "vite-plugin-css-injected-by-js": "^3.1.1",
-        "vite-plugin-svgr": "^3.2.0"
+        "vite-plugin-css-injected-by-js": "^3.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
-    },
-    "node_modules/@contentful/experience-builder-storybook-addon": {
-      "resolved": "packages/storybook-addon",
-      "link": true
     },
     "node_modules/@contentful/experience-builder-components": {
       "resolved": "packages/components",
       "link": true
     },
-    "node_modules/@contentful/experience-builder/node_modules/vite-plugin-svgr": {
-      "version": "3.3.0",
+    "node_modules/@contentful/experience-builder-storybook-addon": {
+      "resolved": "packages/storybook-addon",
+      "link": true
+    },
+    "node_modules/@contentful/experience-builder-types": {
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.4",
-        "@svgr/core": "^8.1.0",
-        "@svgr/plugin-jsx": "^8.1.0"
-      },
-      "peerDependencies": {
-        "vite": "^2.6.0 || 3 || 4"
+        "@contentful/visual-sdk": "^1.0.0-alpha.26",
+        "contentful": "^10.6.10"
       }
     },
     "node_modules/@contentful/f36-accordion": {
@@ -4371,6 +4386,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
@@ -4383,6 +4399,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -4390,6 +4407,7 @@
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.1.2",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -4406,10 +4424,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -4510,18 +4530,16 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/auth-token": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@lerna/create/node_modules/@octokit/core": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -4537,9 +4555,8 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/endpoint": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
@@ -4551,9 +4568,8 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/graphql": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
@@ -4565,15 +4581,13 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/openapi-types": {
       "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lerna/create/node_modules/@octokit/plugin-paginate-rest": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/tsconfig": "^1.0.2",
         "@octokit/types": "^9.2.3"
@@ -4587,9 +4601,8 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^10.0.0"
       },
@@ -4602,18 +4615,16 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@lerna/create/node_modules/@octokit/request": {
       "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
         "@octokit/request-error": "^3.0.0",
@@ -4628,9 +4639,8 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/request-error": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
@@ -4642,9 +4652,8 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/rest": {
       "version": "19.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
-      "integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/core": "^4.2.1",
         "@octokit/plugin-paginate-rest": "^6.1.2",
@@ -4657,24 +4666,21 @@
     },
     "node_modules/@lerna/create/node_modules/@octokit/types": {
       "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/@lerna/create/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/@lerna/create/node_modules/chalk": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4688,9 +4694,8 @@
     },
     "node_modules/@lerna/create/node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -4699,15 +4704,13 @@
     },
     "node_modules/@lerna/create/node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lerna/create/node_modules/execa": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -4728,9 +4731,8 @@
     },
     "node_modules/@lerna/create/node_modules/get-stream": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4740,9 +4742,8 @@
     },
     "node_modules/@lerna/create/node_modules/glob": {
       "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^8.0.2",
@@ -4758,9 +4759,8 @@
     },
     "node_modules/@lerna/create/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4770,18 +4770,16 @@
     },
     "node_modules/@lerna/create/node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@lerna/create/node_modules/glob/node_modules/minimatch": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4794,24 +4792,21 @@
     },
     "node_modules/@lerna/create/node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@lerna/create/node_modules/is-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@lerna/create/node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4821,9 +4816,8 @@
     },
     "node_modules/@lerna/create/node_modules/load-json-file": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
-      "integrity": "sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.15",
         "parse-json": "^5.0.0",
@@ -4836,9 +4830,8 @@
     },
     "node_modules/@lerna/create/node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -4851,9 +4844,8 @@
     },
     "node_modules/@lerna/create/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4863,18 +4855,16 @@
     },
     "node_modules/@lerna/create/node_modules/minipass": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@lerna/create/node_modules/node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4892,9 +4882,8 @@
     },
     "node_modules/@lerna/create/node_modules/p-queue": {
       "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -4908,9 +4897,8 @@
     },
     "node_modules/@lerna/create/node_modules/pify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4920,9 +4908,8 @@
     },
     "node_modules/@lerna/create/node_modules/rimraf": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^9.2.0"
       },
@@ -4938,27 +4925,24 @@
     },
     "node_modules/@lerna/create/node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@lerna/create/node_modules/type-fest": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@lerna/create/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -4969,9 +4953,8 @@
     },
     "node_modules/@lerna/create/node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -4981,9 +4964,8 @@
     },
     "node_modules/@lerna/create/node_modules/yargs": {
       "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -5099,9 +5081,8 @@
     },
     "node_modules/@npmcli/git/node_modules/which": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5167,9 +5148,8 @@
     },
     "node_modules/@npmcli/promise-spawn/node_modules/which": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5197,9 +5177,8 @@
     },
     "node_modules/@npmcli/run-script/node_modules/which": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5249,9 +5228,8 @@
     },
     "node_modules/@nx/devkit/node_modules/enquirer": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -5261,9 +5239,8 @@
     },
     "node_modules/@nx/devkit/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5287,9 +5264,8 @@
     },
     "node_modules/@nx/devkit/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@nx/nx-darwin-arm64": {
       "version": "16.9.1",
@@ -5301,150 +5277,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-darwin-x64": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.9.1.tgz",
-      "integrity": "sha512-b1Hw1AmKrR+Kp361WTiKC1RFoQwERyW9R/9XJGNIdgtr+V2wa775eCEdxB9r9mwCqyEmM9iVadpRHPaFSAfQfQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-freebsd-x64": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.9.1.tgz",
-      "integrity": "sha512-jscl/Xu86tLQYbC8b1wy9FjEgGyuLpYnvP9d+34AHDi6CbCNSodbv93xFDlfYcLOeOD/mJXqR1Ru/1MF86OB5A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.9.1.tgz",
-      "integrity": "sha512-NMAyxjYv9y4LwzU76htcPWfdmRoN/ZziTNKT3jaMbn38x4e7DoXYs9GGh267z45yWHscQWoV0v+X39LmB819aQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.9.1.tgz",
-      "integrity": "sha512-A5UbK5rFhqzs3kMiEKA+xr3LAJsQBA97VDyMH6WPraSl+XRIt4EePx0MyEqo1pnEgeuoOCvR1tjDot5E7ldInw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.9.1.tgz",
-      "integrity": "sha512-eIn5PnKH7Y/u1LuanAM0wPNdcb9Z7seDjQzQ0hFMCCvV75Z8A02ztbiueLGaEsDLx35MPBdBmuyo4hsmvmLgpg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.9.1.tgz",
-      "integrity": "sha512-MMvhoS1pZjyIjwfeZNH2dDZuVF2xxURLTXC4UmmpY/wOWCuXhvD7QUv5A5QShxfaVXmXceo/fGLK+/Qm5e2+7g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.9.1.tgz",
-      "integrity": "sha512-ca0d00YCHo0+OIT80MZdtseJj9wTlWMucmdm0OCXLf/l+Dma4MO4LR09WMH2VIpjoz4Gj7+xP0QtKtH4fWFD8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.9.1.tgz",
-      "integrity": "sha512-UIDAWH6/LfouFaXLJWyZKggzH/698lSrLkEE1fa9VrrGEOhumk7MPAVQc/XxgkWgPDDR1TJl0ij+J1bOREn73Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.9.1.tgz",
-      "integrity": "sha512-isnElU5RaQEGPAJhx6VNY0P/avD79s146kmZOn1Ff5fAjReqR7kRxSWXQOdIqc6nPH9Y0c9wNwEAuhBJoor+Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -6420,6 +6252,7 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -6630,9 +6463,8 @@
     },
     "node_modules/@storybook/addon-essentials": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-7.5.1.tgz",
-      "integrity": "sha512-/jaUZXV+mE/2G5PgEpFKm4lFEHluWn6GFR/pg+hphvHOzBGA3Y75JMgUfJ5CDYHB1dAVSf9JrPOd8Eb1tpESfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/addon-actions": "7.5.1",
         "@storybook/addon-backgrounds": "7.5.1",
@@ -6674,9 +6506,8 @@
     },
     "node_modules/@storybook/addon-interactions": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-7.5.1.tgz",
-      "integrity": "sha512-m9yohFYil+UBwYKFxHYdsAsn8PBCPl6HY/FSgfrDc5PiqT1Ya7paXopimyy9ok+VQt/RC8sEWIm809ONEoxosw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/client-logger": "7.5.1",
         "@storybook/components": "7.5.1",
@@ -6711,9 +6542,8 @@
     },
     "node_modules/@storybook/addon-links": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-7.5.1.tgz",
-      "integrity": "sha512-KDiQYAVNXxuVTB3QLFZxHlfT8q4KnlNKY+0OODvgD5o1FqFpIyUiR5mIBL4SZMRj2EtwrR3KmZ2UPccFZdu9vw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/client-logger": "7.5.1",
         "@storybook/core-events": "7.5.1",
@@ -6776,9 +6606,8 @@
     },
     "node_modules/@storybook/addon-onboarding": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-onboarding/-/addon-onboarding-1.0.8.tgz",
-      "integrity": "sha512-3WwCocUuTibHWO89uzAbeONEn6x9NkmxA0mOU4rYPhEsMQ4NDNDD1GXcievZmpwt5VviFgw5FRx8+BxPn54YmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/telemetry": "^7.1.0-alpha.32",
         "react-confetti": "^6.1.0"
@@ -6881,8 +6710,7 @@
     },
     "node_modules/@storybook/blocks": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.5.1.tgz",
-      "integrity": "sha512-7b69p6kDdgmlejEMM2mW6/Lz4OmU/R3Qr+TpKnPcV5iS7ADxRQEQCTEMoQ5RyLJf0vDRh/7Ljn/RMo8Ux3X7JA==",
+      "license": "MIT",
       "dependencies": {
         "@storybook/channels": "7.5.1",
         "@storybook/client-logger": "7.5.1",
@@ -7636,9 +7464,8 @@
     },
     "node_modules/@storybook/react": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-7.5.1.tgz",
-      "integrity": "sha512-IG97c30fFSmPyGpJ1awHC/+9XnCTqleeOQwROXjroMHSm8m/JTWpHMVLyM1x7b6VAnBhNHWJ+oXLZe/hXkXfpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/client-logger": "7.5.1",
         "@storybook/core-client": "7.5.1",
@@ -7695,9 +7522,8 @@
     },
     "node_modules/@storybook/react-vite": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-7.5.1.tgz",
-      "integrity": "sha512-996/CtOqTjDWMKBGcHG8pwIVlORnoknLD+OTkPXl+aAl9oM9jUtc7psVKLJKGHSHTlVElM2wMTwIHnJ4yeP7bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "0.3.0",
         "@rollup/pluginutils": "^5.0.2",
@@ -7826,6 +7652,7 @@
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7840,6 +7667,7 @@
     },
     "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7854,6 +7682,7 @@
     },
     "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7868,6 +7697,7 @@
     },
     "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7882,6 +7712,7 @@
     },
     "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7896,6 +7727,7 @@
     },
     "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7910,6 +7742,7 @@
     },
     "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7924,6 +7757,7 @@
     },
     "node_modules/@svgr/babel-plugin-transform-svg-component": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7938,6 +7772,7 @@
     },
     "node_modules/@svgr/babel-preset": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
@@ -7962,6 +7797,7 @@
     },
     "node_modules/@svgr/core": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
@@ -7980,6 +7816,7 @@
     },
     "node_modules/@svgr/hast-util-to-babel-ast": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.21.3",
@@ -7995,6 +7832,7 @@
     },
     "node_modules/@svgr/plugin-jsx": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
@@ -8309,6 +8147,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -8450,8 +8289,7 @@
     },
     "node_modules/@types/prompts": {
       "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.7.tgz",
-      "integrity": "sha512-5zTamE+QQM4nR6Ab3yHK+ovWuhLJXaa2ZLt3mT1en8U3ubWtjVT1vXDaVFC2+cL89uVn7Y+gIq5B3IcVvBl5xQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "kleur": "^3.0.3"
@@ -9228,9 +9066,8 @@
     },
     "node_modules/@zkochan/js-yaml/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9692,7 +9529,7 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.5.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -10081,6 +9918,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.22.1",
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10371,6 +10209,7 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10397,9 +10236,8 @@
     },
     "node_modules/camelcase-keys/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -10417,6 +10255,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001554",
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11070,11 +10909,11 @@
       }
     },
     "node_modules/contentful": {
-      "version": "10.6.4",
+      "version": "10.6.12",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^1.4.0",
+        "axios": "^1.6.0",
         "contentful-resolve-response": "^1.8.1",
         "contentful-sdk-core": "^8.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -11196,9 +11035,8 @@
     },
     "node_modules/conventional-changelog-core/node_modules/find-up": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -11208,9 +11046,8 @@
     },
     "node_modules/conventional-changelog-core/node_modules/locate-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -11221,9 +11058,8 @@
     },
     "node_modules/conventional-changelog-core/node_modules/p-limit": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -11233,9 +11069,8 @@
     },
     "node_modules/conventional-changelog-core/node_modules/p-locate": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -11245,27 +11080,24 @@
     },
     "node_modules/conventional-changelog-core/node_modules/p-try": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/conventional-changelog-core/node_modules/read-pkg-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
@@ -11353,6 +11185,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -11387,6 +11220,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
@@ -11425,10 +11259,12 @@
     },
     "node_modules/cosmiconfig/node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12341,6 +12177,7 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -12469,6 +12306,7 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.566",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -12542,6 +12380,7 @@
     },
     "node_modules/entities": {
       "version": "4.5.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -12923,9 +12762,8 @@
     },
     "node_modules/eslint-plugin-storybook": {
       "version": "0.6.15",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.15.tgz",
-      "integrity": "sha512-lAGqVAJGob47Griu29KXYowI4G7KwMoJDOkEip8ujikuDLxU+oWJ1l0WL6F2oDO4QiyUFXvtDkEkISMOPzo+7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/csf": "^0.0.1",
         "@typescript-eslint/utils": "^5.45.0",
@@ -13231,6 +13069,7 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -13982,6 +13821,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -14147,9 +13987,8 @@
     },
     "node_modules/get-pkg-repo/node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -14158,15 +13997,13 @@
     },
     "node_modules/get-pkg-repo/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-pkg-repo/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14179,24 +14016,21 @@
     },
     "node_modules/get-pkg-repo/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-pkg-repo/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/get-pkg-repo/node_modules/through2": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -14204,9 +14038,8 @@
     },
     "node_modules/get-pkg-repo/node_modules/yargs": {
       "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -14433,9 +14266,8 @@
     },
     "node_modules/gitconfiglocal/node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/github-slugger": {
       "version": "1.5.0",
@@ -14523,6 +14355,7 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14764,9 +14597,8 @@
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14776,9 +14608,8 @@
     },
     "node_modules/hosted-git-info/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/html-entities": {
       "version": "2.4.0",
@@ -15047,9 +14878,8 @@
     },
     "node_modules/import-local/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -15060,9 +14890,8 @@
     },
     "node_modules/import-local/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -15072,9 +14901,8 @@
     },
     "node_modules/import-local/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -15087,9 +14915,8 @@
     },
     "node_modules/import-local/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -15099,9 +14926,8 @@
     },
     "node_modules/import-local/node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -15239,9 +15065,8 @@
     },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -15754,6 +15579,7 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15931,9 +15757,8 @@
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -15943,9 +15768,8 @@
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -15957,9 +15781,8 @@
     },
     "node_modules/jest-diff/node_modules/react-is": {
       "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
@@ -16238,6 +16061,7 @@
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -16276,6 +16100,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -16487,18 +16312,16 @@
     },
     "node_modules/lerna/node_modules/@octokit/auth-token": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/lerna/node_modules/@octokit/core": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -16514,9 +16337,8 @@
     },
     "node_modules/lerna/node_modules/@octokit/endpoint": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
@@ -16528,9 +16350,8 @@
     },
     "node_modules/lerna/node_modules/@octokit/graphql": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
@@ -16542,15 +16363,13 @@
     },
     "node_modules/lerna/node_modules/@octokit/openapi-types": {
       "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-      "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lerna/node_modules/@octokit/plugin-paginate-rest": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/tsconfig": "^1.0.2",
         "@octokit/types": "^9.2.3"
@@ -16564,9 +16383,8 @@
     },
     "node_modules/lerna/node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^10.0.0"
       },
@@ -16579,18 +16397,16 @@
     },
     "node_modules/lerna/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/lerna/node_modules/@octokit/request": {
       "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
         "@octokit/request-error": "^3.0.0",
@@ -16605,9 +16421,8 @@
     },
     "node_modules/lerna/node_modules/@octokit/request-error": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "deprecation": "^2.0.0",
@@ -16619,9 +16434,8 @@
     },
     "node_modules/lerna/node_modules/@octokit/rest": {
       "version": "19.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
-      "integrity": "sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/core": "^4.2.1",
         "@octokit/plugin-paginate-rest": "^6.1.2",
@@ -16634,24 +16448,21 @@
     },
     "node_modules/lerna/node_modules/@octokit/types": {
       "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }
     },
     "node_modules/lerna/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/lerna/node_modules/chalk": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16665,9 +16476,8 @@
     },
     "node_modules/lerna/node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -16676,15 +16486,13 @@
     },
     "node_modules/lerna/node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lerna/node_modules/execa": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -16705,9 +16513,8 @@
     },
     "node_modules/lerna/node_modules/get-stream": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16717,9 +16524,8 @@
     },
     "node_modules/lerna/node_modules/glob": {
       "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^8.0.2",
@@ -16735,9 +16541,8 @@
     },
     "node_modules/lerna/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -16747,18 +16552,16 @@
     },
     "node_modules/lerna/node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/lerna/node_modules/glob/node_modules/minimatch": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -16771,24 +16574,21 @@
     },
     "node_modules/lerna/node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lerna/node_modules/is-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lerna/node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -16798,9 +16598,8 @@
     },
     "node_modules/lerna/node_modules/load-json-file": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
-      "integrity": "sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.15",
         "parse-json": "^5.0.0",
@@ -16813,9 +16612,8 @@
     },
     "node_modules/lerna/node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -16828,9 +16626,8 @@
     },
     "node_modules/lerna/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -16840,18 +16637,16 @@
     },
     "node_modules/lerna/node_modules/minipass": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lerna/node_modules/node-fetch": {
       "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -16869,9 +16664,8 @@
     },
     "node_modules/lerna/node_modules/p-queue": {
       "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -16885,9 +16679,8 @@
     },
     "node_modules/lerna/node_modules/pify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16897,9 +16690,8 @@
     },
     "node_modules/lerna/node_modules/rimraf": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^9.2.0"
       },
@@ -16915,27 +16707,24 @@
     },
     "node_modules/lerna/node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lerna/node_modules/type-fest": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lerna/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -16946,9 +16735,8 @@
     },
     "node_modules/lerna/node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -16958,9 +16746,8 @@
     },
     "node_modules/lerna/node_modules/yargs": {
       "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -17697,6 +17484,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.random": {
+      "version": "3.2.0",
+      "license": "MIT"
+    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "dev": true,
@@ -17714,6 +17505,10 @@
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
+      "license": "MIT"
+    },
+    "node_modules/lodash.times": {
+      "version": "4.3.2",
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -17799,6 +17594,7 @@
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -17806,6 +17602,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -18028,9 +17825,8 @@
     },
     "node_modules/meow/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -18046,9 +17842,8 @@
     },
     "node_modules/meow/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -18058,9 +17853,8 @@
     },
     "node_modules/meow/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -18073,9 +17867,8 @@
     },
     "node_modules/meow/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -18272,9 +18065,8 @@
     },
     "node_modules/minimist-options/node_modules/is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18310,9 +18102,8 @@
     },
     "node_modules/minipass-collect/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minipass-fetch": {
       "version": "3.0.4",
@@ -18362,9 +18153,8 @@
     },
     "node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minipass-json-stream": {
       "version": "1.0.1",
@@ -18388,9 +18178,8 @@
     },
     "node_modules/minipass-json-stream/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -18416,9 +18205,8 @@
     },
     "node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
@@ -18444,9 +18232,8 @@
     },
     "node_modules/minipass-sized/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
@@ -18610,6 +18397,7 @@
     },
     "node_modules/no-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -18691,9 +18479,8 @@
     },
     "node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18749,6 +18536,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.13",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -18853,9 +18641,8 @@
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -18873,9 +18660,8 @@
     },
     "node_modules/npm-package-arg/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/npm-packlist": {
       "version": "5.1.1",
@@ -19296,15 +19082,13 @@
     },
     "node_modules/nx/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/nx/node_modules/cli-spinners": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -19314,9 +19098,8 @@
     },
     "node_modules/nx/node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -19325,18 +19108,16 @@
     },
     "node_modules/nx/node_modules/define-lazy-prop": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/nx/node_modules/dotenv": {
       "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -19346,9 +19127,8 @@
     },
     "node_modules/nx/node_modules/enquirer": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -19374,9 +19154,8 @@
     },
     "node_modules/nx/node_modules/is-docker": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -19389,9 +19168,8 @@
     },
     "node_modules/nx/node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -19401,18 +19179,16 @@
     },
     "node_modules/nx/node_modules/lines-and-columns": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
-      "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/nx/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -19422,9 +19198,8 @@
     },
     "node_modules/nx/node_modules/minimatch": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -19434,9 +19209,8 @@
     },
     "node_modules/nx/node_modules/open": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -19481,9 +19255,8 @@
     },
     "node_modules/nx/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/nx/node_modules/yargs": {
       "version": "17.7.2",
@@ -22216,9 +21989,8 @@
     },
     "node_modules/redent/node_modules/strip-indent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -22470,9 +22242,8 @@
     },
     "node_modules/resolve-global/node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -23224,6 +22995,7 @@
     },
     "node_modules/snake-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -23269,9 +23041,8 @@
     },
     "node_modules/sort-keys/node_modules/is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23416,9 +23187,8 @@
     },
     "node_modules/ssri/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/stable": {
       "version": "0.1.8",
@@ -23449,9 +23219,8 @@
     },
     "node_modules/storybook": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.5.1.tgz",
-      "integrity": "sha512-Wg3j3z5H03PYnEcmlnhf6bls0OtjmsNPsQ93dTV8F4AweqBECwzjf94Wj++NrP3X+WbfMoCbBU6LRFuEyzCCxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/cli": "7.5.1"
       },
@@ -23752,6 +23521,7 @@
     },
     "node_modules/svg-parser": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/svgo": {
@@ -23913,9 +23683,8 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/telejson": {
       "version": "7.2.0",
@@ -24664,7 +24433,7 @@
     },
     "node_modules/typescript": {
       "version": "5.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -24903,6 +24672,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -25496,9 +25266,8 @@
     },
     "node_modules/write-json-file/node_modules/detect-indent": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -25599,6 +25368,7 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
@@ -25702,10 +25472,11 @@
       "version": "0.0.1-alpha.10",
       "license": "MIT",
       "dependencies": {
-        "@contentful/experience-builder": "^1.1.0-alpha.75",
+        "@contentful/experience-builder": "^2.8.0",
         "@contentful/rich-text-react-renderer": "^15.17.2"
       },
       "devDependencies": {
+        "@contentful/experience-builder-storybook-addon": "*",
         "@rollup/plugin-commonjs": "^25.0.4",
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-terser": "^0.4.3",
@@ -25743,25 +25514,6 @@
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
-      }
-    },
-    "packages/components/node_modules/@contentful/experience-builder": {
-      "version": "1.1.0-alpha.76",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.2.1",
-        "@contentful/visual-sdk": "^1.0.0-alpha.9",
-        "classnames": "^2.3.2",
-        "contentful": "^10.3.0",
-        "csstype": "^3.1.2",
-        "lodash.get": "^4.4.2",
-        "lodash.omit": "^4.5.0",
-        "lodash.throttle": "^4.1.1",
-        "md5": "^2.3.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "vite-plugin-css-injected-by-js": "^3.1.1",
-        "vite-plugin-svgr": "^3.2.0"
       }
     },
     "packages/components/node_modules/@storybook/testing-library": {
@@ -25882,18 +25634,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/components/node_modules/vite-plugin-svgr": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.4",
-        "@svgr/core": "^8.1.0",
-        "@svgr/plugin-jsx": "^8.1.0"
-      },
-      "peerDependencies": {
-        "vite": "^2.6.0 || 3 || 4"
-      }
-    },
     "packages/create-experience-builder": {
       "version": "0.0.1-alpha.0",
       "license": "MIT",
@@ -25915,8 +25655,7 @@
     },
     "packages/create-experience-builder/node_modules/kleur": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -25927,7 +25666,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.1",
-        "@contentful/experience-builder": "2.0.2",
+        "@contentful/experience-builder": "^2.8.0",
         "@contentful/f36-components": "^4.52.1",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-workbench": "^4.21.0",
@@ -25985,9 +25724,6 @@
         }
       }
     },
-    "packages/storybook-addon/dist": {
-      "extraneous": true
-    },
     "packages/storybook-addon/node_modules/@types/node": {
       "version": "18.18.7",
       "dev": true,
@@ -26025,8 +25761,10 @@
     "packages/test-app": {
       "version": "0.0.0",
       "dependencies": {
-        "@contentful/experience-builder": "^1.1.0-alpha.75",
+        "@contentful/experience-builder": "^2.8.0",
         "@contentful/experience-builder-components": "*",
+        "@contentful/experience-builder-storybook-addon": "*",
+        "contentful": "^10.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0"
@@ -26055,31 +25793,10 @@
         "vite": "^4.4.5"
       }
     },
-    "packages/test-app/node_modules/@contentful/experience-builder": {
-      "version": "1.1.0-alpha.76",
-      "resolved": "https://registry.npmjs.org/@contentful/experience-builder/-/experience-builder-1.1.0-alpha.76.tgz",
-      "integrity": "sha512-oxZ6zoPTd0kJgxnKO9w+zqeYLTIjGqA+Oug2+0ce1KGoUCuF5d5i1bIOn5gMLr/Nu/VHy5so+6C3xXoonrHbow==",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.2.1",
-        "@contentful/visual-sdk": "^1.0.0-alpha.9",
-        "classnames": "^2.3.2",
-        "contentful": "^10.3.0",
-        "csstype": "^3.1.2",
-        "lodash.get": "^4.4.2",
-        "lodash.omit": "^4.5.0",
-        "lodash.throttle": "^4.1.1",
-        "md5": "^2.3.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "vite-plugin-css-injected-by-js": "^3.1.1",
-        "vite-plugin-svgr": "^3.2.0"
-      }
-    },
     "packages/test-app/node_modules/@storybook/testing-library": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.2.2.tgz",
-      "integrity": "sha512-L8sXFJUHmrlyU2BsWWZGuAjv39Jl1uAqUHdxmN42JY15M4+XCMjGlArdCCjDe1wpTSW6USYISA9axjZojgtvnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "^9.0.0",
         "@testing-library/user-event": "^14.4.0",
@@ -26088,9 +25805,8 @@
     },
     "packages/test-app/node_modules/@testing-library/dom": {
       "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -26107,9 +25823,8 @@
     },
     "packages/test-app/node_modules/@testing-library/user-event": {
       "version": "14.5.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
-      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -26120,9 +25835,8 @@
     },
     "packages/test-app/node_modules/@vitejs/plugin-react": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.1.0.tgz",
-      "integrity": "sha512-rM0SqazU9iqPUraQ2JlIvReeaxOoRj6n+PzB1C0cBzIbd8qP336nC39/R9yPi3wVcah7E7j/kdU1uCUqMEU4OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.22.20",
         "@babel/plugin-transform-react-jsx-self": "^7.22.5",
@@ -26139,18 +25853,16 @@
     },
     "packages/test-app/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "packages/test-app/node_modules/glob": {
       "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.5",
@@ -26170,9 +25882,8 @@
     },
     "packages/test-app/node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -26185,9 +25896,8 @@
     },
     "packages/test-app/node_modules/rimraf": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -26199,19 +25909,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/test-app/node_modules/vite-plugin-svgr": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-3.3.0.tgz",
-      "integrity": "sha512-vWZMCcGNdPqgziYFKQ3Y95XP0d0YGp28+MM3Dp9cTa/px5CKcHHrIoPl2Jw81rgVm6/ZUNONzjXbZQZ7Kw66og==",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.4",
-        "@svgr/core": "^8.1.0",
-        "@svgr/plugin-jsx": "^8.1.0"
-      },
-      "peerDependencies": {
-        "vite": "^2.6.0 || 3 || 4"
       }
     }
   }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,7 +69,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@contentful/experience-builder": "^1.1.0-alpha.75",
+    "@contentful/experience-builder": "^2.8.0",
     "@contentful/rich-text-react-renderer": "^15.17.2"
   }
 }

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -114,7 +114,7 @@
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.23.1",
-    "@contentful/experience-builder": "2.0.2",
+    "@contentful/experience-builder": "^2.8.0",
     "@contentful/f36-components": "^4.52.1",
     "@contentful/f36-tokens": "^4.0.2",
     "@contentful/f36-workbench": "^4.21.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@contentful/experience-builder": "^2.11.0",
+    "@contentful/experience-builder": "^2.8.0",
     "@contentful/experience-builder-components": "*",
     "@contentful/experience-builder-storybook-addon": "*",
     "contentful": "^10.5.1",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -15,9 +15,10 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@contentful/experience-builder": "^1.1.0-alpha.75",
+    "@contentful/experience-builder": "^2.11.0",
     "@contentful/experience-builder-components": "*",
     "@contentful/experience-builder-storybook-addon": "*",
+    "contentful": "^10.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0"

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -8,7 +8,7 @@ import { createClient } from 'contentful';
 import { useExperienceBuilderComponents } from '@contentful/experience-builder-components';
 import '@contentful/experience-builder-components/styles.css';
 import { useParams } from 'react-router-dom';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 const isPreview = window.location.search.includes('isPreview=true');
 const mode = isPreview ? 'preview' : (import.meta.env.VITE_MODE as ExternalSDKMode) || 'delivery';
@@ -25,23 +25,15 @@ const client = createClient({
 
 export default function Page() {
   const localeCode = 'en-US';
-  const { slug } = useParams<{ slug: string }>();
-  const hasFetched = useRef(false);
+  const { slug = '' } = useParams<{ slug: string }>();
 
   const { experience, fetchBySlug } = useFetchExperience({ client, mode });
 
   useExperienceBuilderComponents(defineComponents);
 
   useEffect(() => {
-    const asyncFetch = async () => {
-      if (slug) {
-        await fetchBySlug({ experienceTypeId, slug, localeCode });
-      }
-    };
-
-    if (!hasFetched.current) {
-      asyncFetch();
-      hasFetched.current = true;
+    if (slug) {
+      fetchBySlug({ experienceTypeId, slug, localeCode });
     }
   }, [fetchBySlug, slug]);
 

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -25,7 +25,7 @@ const client = createClient({
 
 export default function Page() {
   const localeCode = 'en-US';
-  const { slug = '' } = useParams<{ slug: string }>();
+  const { slug } = useParams<{ slug: string }>();
 
   const { experience, fetchBySlug } = useFetchExperience({ client, mode });
 

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -2,20 +2,40 @@ import {
   useFetchExperience,
   defineComponents,
   ExperienceRoot,
+  ExternalSDKMode,
 } from '@contentful/experience-builder';
 import { createClient } from 'contentful';
 import { useExperienceBuilderComponents } from '@contentful/experience-builder-components';
 import '@contentful/experience-builder-components/styles.css';
+import { useParams } from 'react-router-dom';
+import { useEffect } from 'react';
+
+const isPreview = window.location.search.includes('isPreview=true');
+const mode = isPreview ? 'preview' : (import.meta.env.VITE_MODE as ExternalSDKMode) || 'delivery';
+const experienceTypeId = import.meta.env.VITE_EB_TYPE_ID || 'layout';
 
 const client = createClient({
   space: import.meta.env.VITE_SPACE_ID || '',
   environment: import.meta.env.VITE_ENVIRONMENT_ID || 'master',
-  host: import.meta.env.VITE_PREVIEW_HOST || 'preview.contentful.com',
-  accessToken: import.meta.env.VITE_PREVIEW_ACCESS_TOKEN || '',
+  host: isPreview ? 'preview.contentful.com' : 'cdn.contentful.com',
+  accessToken: isPreview
+    ? import.meta.env.VITE_PREVIEW_ACCESS_TOKEN
+    : import.meta.env.VITE_ACCESS_TOKEN,
 });
 
 export default function Page() {
-  useFetchExperience({ client, mode: 'preview' });
+  const localeCode = 'en-US';
+  const { slug = '' } = useParams<{ slug: string }>();
+
+  const { experience, fetchBySlug } = useFetchExperience({ client, mode });
+
   useExperienceBuilderComponents(defineComponents);
-  return <ExperienceRoot locale="en-US" />;
+
+  useEffect(() => {
+    if (slug) {
+      fetchBySlug({ experienceTypeId, slug, localeCode });
+    }
+  }, [fetchBySlug, slug]);
+
+  return <ExperienceRoot experience={experience} locale={localeCode} />;
 }

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -1,51 +1,21 @@
-import { useExperienceBuilder, ExperienceRoot } from '@contentful/experience-builder';
-import React, { useMemo } from 'react';
+import {
+  useFetchExperience,
+  defineComponents,
+  ExperienceRoot,
+} from '@contentful/experience-builder';
 import { createClient } from 'contentful';
-import { useParams, useSearchParams } from 'react-router-dom';
 import { useExperienceBuilderComponents } from '@contentful/experience-builder-components';
 import '@contentful/experience-builder-components/styles.css';
-import { ExternalSDKMode } from '@contentful/experience-builder/dist/types';
 
-const experienceTypeId = import.meta.env.VITE_EB_TYPE_ID || 'layout';
+const client = createClient({
+  space: import.meta.env.VITE_SPACE_ID || '',
+  environment: import.meta.env.VITE_ENVIRONMENT_ID || 'master',
+  host: import.meta.env.VITE_PREVIEW_HOST || 'preview.contentful.com',
+  accessToken: import.meta.env.VITE_PREVIEW_ACCESS_TOKEN || '',
+});
 
-const Page: React.FC = () => {
-  const { slug } = useParams<{ slug: string }>();
-  const [qs] = useSearchParams();
-
-  const isPreview = qs.get('isPreview') === 'true';
-  const isEditor = true; // qs.get('isEditor') === 'true';
-
-  const mode = isEditor ? 'editor' : isPreview ? 'preview' : 'delivery';
-
-  const client = useMemo(() => {
-    const space = import.meta.env.VITE_SPACE_ID || '';
-    const environment = import.meta.env.VITE_ENVIRONMENT_ID || 'master';
-    const accessToken = isPreview
-      ? import.meta.env.VITE_PREVIEW_ACCESS_TOKEN
-      : import.meta.env.VITE_ACCESS_TOKEN;
-    const host = isPreview ? 'preview.contentful.com' : 'cdn.contentful.com';
-
-    return createClient({
-      space,
-      environment,
-      host,
-      accessToken: accessToken as string,
-    });
-  }, [isPreview]);
-
-  const { experience, defineComponents } = useExperienceBuilder({
-    experienceTypeId,
-    client,
-    mode: mode as ExternalSDKMode,
-  });
-
+export default function Page() {
+  useFetchExperience({ client, mode: 'preview' });
   useExperienceBuilderComponents(defineComponents);
-
-  return (
-    <>
-      <ExperienceRoot slug={slug || '/'} experience={experience} locale={'en-US'} />
-    </>
-  );
-};
-
-export default Page;
+  return <ExperienceRoot locale="en-US" />;
+}

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -32,9 +32,11 @@ export default function Page() {
   useExperienceBuilderComponents(defineComponents);
 
   useEffect(() => {
-    if (slug) {
-      fetchBySlug({ experienceTypeId, slug, localeCode });
-    }
+    (async () => {
+      if (slug) {
+        await fetchBySlug({ experienceTypeId, slug, localeCode });
+      }
+    })();
   }, [fetchBySlug, slug]);
 
   return <ExperienceRoot experience={experience} locale={localeCode} />;

--- a/packages/test-app/src/Page.tsx
+++ b/packages/test-app/src/Page.tsx
@@ -8,7 +8,7 @@ import { createClient } from 'contentful';
 import { useExperienceBuilderComponents } from '@contentful/experience-builder-components';
 import '@contentful/experience-builder-components/styles.css';
 import { useParams } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const isPreview = window.location.search.includes('isPreview=true');
 const mode = isPreview ? 'preview' : (import.meta.env.VITE_MODE as ExternalSDKMode) || 'delivery';
@@ -26,17 +26,23 @@ const client = createClient({
 export default function Page() {
   const localeCode = 'en-US';
   const { slug } = useParams<{ slug: string }>();
+  const hasFetched = useRef(false);
 
   const { experience, fetchBySlug } = useFetchExperience({ client, mode });
 
   useExperienceBuilderComponents(defineComponents);
 
   useEffect(() => {
-    (async () => {
+    const asyncFetch = async () => {
       if (slug) {
         await fetchBySlug({ experienceTypeId, slug, localeCode });
       }
-    })();
+    };
+
+    if (!hasFetched.current) {
+      asyncFetch();
+      hasFetched.current = true;
+    }
   }, [fetchBySlug, slug]);
 
   return <ExperienceRoot experience={experience} locale={localeCode} />;

--- a/packages/test-app/src/vite-env.d.ts
+++ b/packages/test-app/src/vite-env.d.ts
@@ -3,8 +3,9 @@
 interface ImportMetaEnv {
   readonly VITE_ENVIRONMENT_ID: string;
   readonly VITE_SPACE_ID: string;
-  readonly VITE_PREVIEW_HOST: string;
+  readonly VITE_ACCESS_TOKEN: string;
   readonly VITE_PREVIEW_ACCESS_TOKEN: string;
+  readonly VITE_EB_TYPE_ID: string;
 }
 
 interface ImportMeta {

--- a/packages/test-app/src/vite-env.d.ts
+++ b/packages/test-app/src/vite-env.d.ts
@@ -3,9 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_ENVIRONMENT_ID: string;
   readonly VITE_SPACE_ID: string;
-  readonly VITE_ACCESS_TOKEN: string;
+  readonly VITE_PREVIEW_HOST: string;
   readonly VITE_PREVIEW_ACCESS_TOKEN: string;
-  readonly VITE_EB_TYPE_ID: string;
 }
 
 interface ImportMeta {

--- a/packages/test-app/vercel.json
+++ b/packages/test-app/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
Updates `test-app` package to the latest SDK

* Runs the SDK in `preview` mode when editing an experience in the UI.
* Runs the SDK in `delivery` mode when accessed outside of the UI (and `?isPreview=true` can be added to the URL to render the draft/preview content outside of the UI)
* Content preview URL can remain as `http://localhost:5173` (no need to add dynamic slug variable)
* Adds rewrite rules for vercel deployment to access pages by slug