### PR TITLE
fix: update exp-builder sdk to 3.0.0 and types to 2.0.0 [ALT-161]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2907,11 +2907,12 @@
       }
     },
     "node_modules/@contentful/experience-builder": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/experience-builder/-/experience-builder-2.13.0.tgz",
-      "integrity": "sha512-QqWElJCuQEEs/NTs3rGIRguRuvpLaOzZzUfnLv9mMe4s1wx73SJCT6V7Dlb9O7ltHdAfN3Hh0NScu0QhM65CBw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/experience-builder/-/experience-builder-3.0.0.tgz",
+      "integrity": "sha512-LnT7LWvjDUE77s0491nxPti5oRCVavEtIO9MdmBdLY+OBVapoy8FWAWF26jkPibAfj8L9HXq/ri5m8v6G0gyMg==",
       "dependencies": {
-        "@contentful/experience-builder-types": "^1.5.0",
+        "@contentful/experience-builder-components": "^0.0.1-alpha.11",
+        "@contentful/experience-builder-types": "^2.0.0",
         "@contentful/rich-text-types": "^16.2.1",
         "@contentful/visual-sdk": "^1.0.0-alpha.26",
         "classnames": "^2.3.2",
@@ -2939,9 +2940,9 @@
       "link": true
     },
     "node_modules/@contentful/experience-builder-types": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@contentful/experience-builder-types/-/experience-builder-types-1.5.0.tgz",
-      "integrity": "sha512-hOt8t1ESAK8j5MBpltjOPf0XtEJf8rxJQJoRBtPNjP1znuBJ6vAxXuSFx73o6UDPf3CZOfxV3tjRos+WN6eAYw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/experience-builder-types/-/experience-builder-types-2.0.0.tgz",
+      "integrity": "sha512-/EiD2MBRsSvJpMUqMeyiv7fomnAMeeJqFjPgSfsWxIxBHGmJKYfkWxfEdKTb3LWTtn2rJss0FtmCoL4X7VgtmQ==",
       "dependencies": {
         "@contentful/visual-sdk": "^1.0.0-alpha.26",
         "contentful": "^10.6.10"
@@ -31259,7 +31260,7 @@
       },
       "devDependencies": {
         "@contentful/experience-builder-storybook-addon": "*",
-        "@contentful/experience-builder-types": "^1.4.0",
+        "@contentful/experience-builder-types": "^2.0.0",
         "@rollup/plugin-commonjs": "^25.0.4",
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-terser": "^0.4.3",
@@ -31512,7 +31513,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.1",
-        "@contentful/experience-builder": "^2.8.0",
+        "@contentful/experience-builder": "^3.0.0",
         "@contentful/f36-components": "^4.52.1",
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-workbench": "^4.21.0",
@@ -31621,7 +31622,7 @@
     "packages/test-app": {
       "version": "0.0.0",
       "dependencies": {
-        "@contentful/experience-builder": "^2.8.0",
+        "@contentful/experience-builder": "^3.0.0",
         "@contentful/experience-builder-components": "*",
         "@contentful/experience-builder-storybook-addon": "*",
         "contentful": "^10.5.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
   ],
   "devDependencies": {
     "@contentful/experience-builder-storybook-addon": "*",
-    "@contentful/experience-builder-types": "^1.4.0",
+    "@contentful/experience-builder-types": "^2.0.0",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-terser": "^0.4.3",

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -114,7 +114,7 @@
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.23.1",
-    "@contentful/experience-builder": "^2.8.0",
+    "@contentful/experience-builder": "^3.0.0",
     "@contentful/f36-components": "^4.52.1",
     "@contentful/f36-tokens": "^4.0.2",
     "@contentful/f36-workbench": "^4.21.0",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -16,7 +16,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@contentful/experience-builder": "^2.8.0",
+    "@contentful/experience-builder": "^3.0.0",
     "@contentful/experience-builder-components": "*",
     "@contentful/experience-builder-storybook-addon": "*",
     "contentful": "^10.5.1",


### PR DESCRIPTION
This changes test-app to use exp-builder sdk 3.0.0 which registers the five components in packages/components and wraps components in a container div by default.

I also bumped the storybook-addon package to use the latest sdk and the components package to use the latest types.