### PR TITLE
Draft: change to DesignTokensDefinition type [ALT-200]

### DIFF
--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -260,6 +260,21 @@ export type Composition = {
   componentSettings?: ExperienceComponentSettings;
 };
 
+type BaseDesignTokensDefinition = {
+  [key: string]: string | BaseDesignTokensDefinition | undefined;
+};
+
+export interface DesignTokensDefinition extends BaseDesignTokensDefinition {
+  spacing?: Record<string, string>;
+  colors?: Record<string, string>;
+  borders?: {
+    [key: string]: {
+      size: string;
+      color: string;
+    };
+  };
+}
+
 export type ExperienceEntry = {
   sys: Entry['sys'];
   fields: Composition;

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -267,12 +267,7 @@ type BaseDesignTokensDefinition = {
 export interface DesignTokensDefinition extends BaseDesignTokensDefinition {
   spacing?: Record<string, string>;
   colors?: Record<string, string>;
-  borders?: {
-    [key: string]: {
-      size: string;
-      color: string;
-    };
-  };
+  borders?: Record<string, { size: string; color: string }>;
 }
 
 export type ExperienceEntry = {

--- a/packages/visual-editor-app/src/Page.tsx
+++ b/packages/visual-editor-app/src/Page.tsx
@@ -1,10 +1,15 @@
-import { useFetchExperience, ExperienceRoot } from '@contentful/experience-builder';
+import {
+  useFetchExperience,
+  ExperienceRoot,
+  defineDesignTokens,
+} from '@contentful/experience-builder';
 import { ExternalSDKMode, VisualEditorMode } from '@contentful/experience-builder-core';
 import { createClient } from 'contentful';
 import { useParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import '@contentful/experience-builder-components/styles.css';
 import './styles.css';
+import { designTokens } from './utils/constants';
 
 const isPreview = window.location.search.includes('isPreview=true');
 const mode = isPreview ? 'preview' : (import.meta.env.VITE_MODE as ExternalSDKMode) || 'delivery';
@@ -29,6 +34,8 @@ const client = createClient({
 export default function Page() {
   const { slug = 'homePage' } = useParams<{ slug: string }>();
   const { experience, fetchBySlug } = useFetchExperience({ client, mode });
+
+  defineDesignTokens(designTokens);
 
   useEffect(() => {
     if (slug) {

--- a/packages/visual-editor-app/src/utils/constants.ts
+++ b/packages/visual-editor-app/src/utils/constants.ts
@@ -1,0 +1,43 @@
+import { DesignTokensDefinition } from '@contentful/experience-builder-core';
+
+export const designTokens: DesignTokensDefinition = {
+  colors: {
+    White: '#fff',
+    Black: '#000',
+    Gray: '#555',
+    Red: '#f00',
+    Green: '#0f0',
+    Blue: '#00f',
+  },
+  spacing: {
+    None: '0',
+    Xs: '4px',
+    Sm: '8px',
+    Md: '16px',
+    Lg: '32px',
+    Xl: '64px',
+    '2Xl': '96px',
+    '3Xl': '128px',
+  },
+  borders: {
+    White: { size: '1px', color: '#fff' },
+    Black: { size: '1px', color: '#000' },
+    Gray: { size: '1px', color: '#555' },
+    Red: { size: '1px', color: '#f00' },
+    Green: { size: '1px', color: '#0f0' },
+    Blue: { size: '1px', color: '#00f' },
+  },
+  // This is a custom example token that is not used in the app
+  // but demonstrates the type of tokens that can be defined
+  unusedCustomExampleTokens: {
+    Key: 'value',
+    Object: {
+      Key: 'value',
+    },
+    Nested: {
+      Object: {
+        Key: 'value',
+      },
+    },
+  },
+};


### PR DESCRIPTION
@ryunsong-contentful and I had discussed changing the `DesignTokensDefinition` type to provide users with details on the expected keys like `spacing`, `colors` and `borders` while still allowing flexibility to define any custom tokens as well.

This is the revised type I came up with to incorporate ideas from our discussion.  I don't think we need to merge this immediately or anything, just wanted to open a draft PR with this change to help remind me later.